### PR TITLE
Fix modifier level code selection ordering

### DIFF
--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -354,23 +354,40 @@ impl Modifiers {
     }
 
     pub fn level_code(&self, mod_type: ModType) -> Option<(u32, Option<u8>)> {
-        self.0.iter().find_map(|(code, modifier)| match modifier {
-            Modifier::Single(mod_kind) => {
-                if mod_kind.get_modkind_from_modtype(mod_type).is_some() {
-                    Some((*code, None))
-                } else {
-                    None
-                }
+        fn priority(mod_kind: &ModKind, mod_type: ModType) -> Option<u8> {
+            match mod_kind {
+                ModKind::Pressed { mod_type: m_t, .. } if *m_t == mod_type => Some(0),
+                ModKind::Latch { mod_type: m_t, .. } if *m_t == mod_type => Some(1),
+                ModKind::Lock { mod_type: m_t, .. } if *m_t == mod_type => Some(2),
+                _ => None,
             }
-            Modifier::Leveled(map) => {
-                for (level, mod_kind) in map {
-                    if mod_kind.get_modkind_from_modtype(mod_type).is_some() {
-                        return Some((*code, Some(*level)));
+        }
+
+        let mut best: Option<(u8, u32, Option<u8>)> = None;
+        for (code, modifier) in &self.0 {
+            match modifier {
+                Modifier::Single(mod_kind) => {
+                    if let Some(rank) = priority(mod_kind, mod_type) {
+                        let candidate = (rank, *code, None);
+                        if best.as_ref().is_none_or(|current| candidate < *current) {
+                            best = Some(candidate);
+                        }
                     }
                 }
-                None
+                Modifier::Leveled(map) => {
+                    for (level, mod_kind) in map {
+                        if let Some(rank) = priority(mod_kind, mod_type) {
+                            let candidate = (rank, *code, Some(*level));
+                            if best.as_ref().is_none_or(|current| candidate < *current) {
+                                best = Some(candidate);
+                            }
+                        }
+                    }
+                }
             }
-        })
+        }
+
+        best.map(|(_, code, level)| (code, level))
     }
 
     pub fn level2_code(&self) -> Option<(u32, Option<u8>)> {


### PR DESCRIPTION
### Motivation

- Workaround FR-related mismatches in `state`, `num_lock`, and `caps_lock` behaviour by improving how a level modifier code is chosen without changing the `level_keymap` data.
- Previously `Modifiers::level_code` returned the first matching entry which could pick a `Lock`-style modifier (e.g. `Shift_Lock`) instead of a more appropriate `Pressed`/`Latch` variant, causing parity differences.

### Description

- Replace the single-pass `find_map` selection in `Modifiers::level_code` with a prioritized selection that ranks modifier kinds so that `Pressed` > `Latch` > `Lock` when matching a `ModType`.
- Implement a local `priority` helper to map `ModKind` → rank (`Pressed` = 0, `Latch` = 1, `Lock` = 2) and scan both `Single` and `Leveled` modifiers to choose the best candidate.
- Use deterministic tie-breaking by considering the tuple `(rank, evdev_code, level)` so results are stable across runs; return the selected `(code, Option<level>)` as before.
- No changes were made to `level_keymap` or other keymap fixup logic.

### Testing

- Ran `cargo fmt` successfully to format the changes.
- Attempted `cargo test -q`, which could not complete because network access to `crates.io` is blocked in this environment (download/config errors), so automated tests could not be executed here.
- Attempted `cargo test --offline`, which also failed because required crates were not available in the local cache, so no unit/integration tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a0201b3efc8328ac171dfb00f43e9a)